### PR TITLE
Fix relative link for data-definition

### DIFF
--- a/src/content/docs/cypher/data-definition/index.mdx
+++ b/src/content/docs/cypher/data-definition/index.mdx
@@ -19,7 +19,7 @@ The choice of using the term "table" over "label" is intentional and explained i
 Click on the card below to learn more about creating tables.
 
 <LinkCard
-    title="CREATE" href="./data-definition/create-table"
+    title="CREATE" href="./create-table"
     description="Create node and relationship tables"
 />
 
@@ -28,7 +28,7 @@ Click on the card below to learn more about creating tables.
 You can update the schema of a table using `ALTER TABLE`.
 
 <LinkCard
-    title="ALTER" href="./data-definition/alter"
+    title="ALTER" href="./alter"
     description="Update the schema of a node or relationship table"
 />
 
@@ -37,7 +37,7 @@ You can update the schema of a table using `ALTER TABLE`.
 You can drop tables from the database with the `DROP TABLE`.
 
 <LinkCard
-    title="DROP" href="./data-definition/drop"
+    title="DROP" href="./drop"
     description="Drop node or relationship table"
 />
 


### PR DESCRIPTION
The documentation is broken due to relative path. The URL for link cards has `data-definition` applied twice. As an example, `https://docs.kuzudb.com/cypher/data-definition/data-definition/create-table` is one of the links in generated doc https://docs.kuzudb.com/cypher/data-definition/